### PR TITLE
Update empirical-bayes.Rmd

### DIFF
--- a/empirical-bayes.Rmd
+++ b/empirical-bayes.Rmd
@@ -190,7 +190,6 @@ career_eb %>%
   arrange(eb_estimate) %>%
   head(5) %>%
   kable(booktabs = TRUE)
-options(digits = 1)
 ```
 
 Notice that in each of these cases, empirical Bayes didn't simply pick the players who had 1 or 2 at-bats and hit on 100% of them. It found players who generally batted well, or poorly, across a long career. What a load off of our minds: we can start using these empirical Bayes estimates in downstream analyses and algorithms, and not worry that we're accidentally letting $0/1$ or $1/1$ cases ruin everything.


### PR DESCRIPTION
Because the digit option is set back to 1, the first two ticks of the y-axe of the graph ebestimatescatter are both labeled 0.2 (page 26 of the book). This is a bit confusing. Maybe we should just leave the digit option at 3?